### PR TITLE
map pins no longer have Profile button

### DIFF
--- a/screens/maps/WideMap.js
+++ b/screens/maps/WideMap.js
@@ -47,10 +47,6 @@ const WideMap = ({ getProfileData, getOrganizations, coords, navigation }) => {
                 style={styles.markerCallout}
               >
                 <Text style={styles.calloutOrgName}>{coordinate.org_name}</Text>
-
-                <View style={styles.calloutButton}>
-                  <Text style={styles.calloutButtonText}>Profile</Text>
-                </View>
               </Callout>
             </Marker>
           );


### PR DESCRIPTION
# Description

The pins on the map now simply show the Org Names.

## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
