### PR TITLE
Fixed back button on view campaign screen

### DIFF
--- a/components/BackButton.js
+++ b/components/BackButton.js
@@ -1,35 +1,27 @@
-import React from 'react';
-import { TouchableOpacity, View, Text } from 'react-native';
+import React from "react";
+import { TouchableOpacity, View, Text } from "react-native";
 
 const DoneButton = props => {
   // console.log(props);
   const handlePress = () => {
-    if (props.override) {
-      props.navigation.navigate('override');
-    } else if (props.popToTop) {
-      props.navigation.popToTop();
-    } else if (props.fromMap) {
-      props.navigation.navigate('MapHome');
-    } else {
-      props.navigation.goBack(null);
-    }
+    props.navigation.goBack(null);
   };
 
   return (
     <TouchableOpacity onPress={handlePress} style={{ padding: 18 }}>
       <View
         style={{
-          alignItems: 'center',
-          justifyContent: 'center',
+          alignItems: "center",
+          justifyContent: "center",
           borderRadius: 5,
           height: 35
         }}
       >
         <Text
           style={{
-            color: '#fff',
+            color: "#fff",
             fontSize: 17,
-            fontFamily: 'Lato'
+            fontFamily: "Lato"
           }}
         >
           Back

--- a/screens/ProScreen.js
+++ b/screens/ProScreen.js
@@ -24,7 +24,7 @@ class ProScreen extends React.Component {
         alignSelf: "center",
         fontFamily: "Lato-Bold"
       },
-      headerLeft: <BackButton navigation={navigation} fromMap={fromMap} />,
+      headerLeft: <BackButton navigation={navigation} />,
       headerRight: <View />
     };
   };

--- a/screens/SupProScreen.js
+++ b/screens/SupProScreen.js
@@ -9,7 +9,6 @@ import BackButton from "../components/BackButton";
 
 const SupProScreen = props => {
   useEffect(() => {
-    console.log("hello?");
     props.getProfileData(props.userId, false, "myProfile");
   });
 

--- a/screens/ViewCampScreen.js
+++ b/screens/ViewCampScreen.js
@@ -43,7 +43,7 @@ class ViewCampScreen extends React.Component {
         flexGrow: 1,
         alignSelf: "center"
       },
-      headerLeft: <BackButton navigation={navigation} popToTop />,
+      headerLeft: <BackButton navigation={navigation} />,
       headerRight: <View />
     };
   };
@@ -234,7 +234,7 @@ class ViewCampScreen extends React.Component {
                     <Text style={styles.timeText}>{timeDiff}</Text>
                   </View>
                   <View style={styles.commentsView}>
-                    <CommentsView  />
+                    <CommentsView />
                   </View>
                   <View style={styles.donateView}>
                     <View style={styles.campMission}>


### PR DESCRIPTION
# Description

Back button from view campaign screen was hard coded to go to map view instead of back one screen. This was fixed so that the back button always takes you back one screen.

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have removed the expo files from my commit
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
