### PR TITLE
Add back button to LocationScreen and DetailScreen

### DIFF
--- a/screens/DetailScreen.js
+++ b/screens/DetailScreen.js
@@ -1,28 +1,29 @@
-import React, { Component } from "react";
-import { View } from "react-native";
-import { ScrollView } from "react-navigation";
-import { connect } from "react-redux";
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { ScrollView } from 'react-navigation';
+import { connect } from 'react-redux';
 
-import DetailHeader from "../components/DetailScreen/DetailHeader";
-import DetailAboutUs from "../components/DetailScreen/DetailAboutUs";
+import DetailHeader from '../components/DetailScreen/DetailHeader';
+import DetailAboutUs from '../components/DetailScreen/DetailAboutUs';
+import BackButton from '../components/BackButton';
 
-import styles from "../constants/screens/MyDetailScreen";
+import styles from '../constants/screens/MyDetailScreen';
 
 class DetailsScreen extends React.Component {
   static navigationOptions = ({ navigation }) => {
     return {
-      title: "Profile",
+      title: 'Profile',
       headerStyle: {
-        backgroundColor: "#323338"
+        backgroundColor: '#323338'
       },
-      headerTintColor: "#fff",
+      headerTintColor: '#fff',
       headerTitleStyle: {
-        textAlign: "center",
+        textAlign: 'center',
         flexGrow: 1,
-        alignSelf: "center",
-        fontFamily: "Lato-Bold"
+        alignSelf: 'center',
+        fontFamily: 'Lato-Bold'
       },
-      headerLeft: () => <View />,
+      headerLeft: () => <BackButton navigation={navigation} />,
       headerRight: () => <View />
     };
   };

--- a/screens/LocationScreen.js
+++ b/screens/LocationScreen.js
@@ -1,28 +1,29 @@
-import React, { Component } from "react";
-import { View } from "react-native";
-import { ScrollView } from "react-navigation";
-import { connect } from "react-redux";
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { ScrollView } from 'react-navigation';
+import { connect } from 'react-redux';
 
-import LocationHeader from "../components/Location/LocationHeader";
-import LocationMap from "../components/Location/LocationMap";
+import LocationHeader from '../components/Location/LocationHeader';
+import LocationMap from '../components/Location/LocationMap';
+import BackButton from '../components/BackButton';
 
-import styles from "../constants/screens/MyDetailScreen";
+import styles from '../constants/screens/MyDetailScreen';
 
 class LocationScreen extends React.Component {
   static navigationOptions = ({ navigation }) => {
     return {
-      title: "Profile",
+      title: 'Profile',
       headerStyle: {
-        backgroundColor: "#323338"
+        backgroundColor: '#323338'
       },
-      headerTintColor: "#fff",
+      headerTintColor: '#fff',
       headerTitleStyle: {
-        textAlign: "center",
+        textAlign: 'center',
         flexGrow: 1,
-        alignSelf: "center",
-        fontFamily: "Lato-Bold"
+        alignSelf: 'center',
+        fontFamily: 'Lato-Bold'
       },
-      headerLeft: () => <View />,
+      headerLeft: () => <BackButton navigation={navigation} />,
       headerRight: () => <View />
     };
   };


### PR DESCRIPTION
# Description

Added a back button to the Location and Details screens when viewing a conservationist's profile

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have removed the expo files from my commit
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
