### PR TITLE
Addressed undefined issue when creating a new campaign

### DIFF
--- a/screens/FeedScreen.js
+++ b/screens/FeedScreen.js
@@ -81,15 +81,20 @@ class FeedScreen extends React.Component {
             {this.props.allCampaigns.length > 0 &&
               this.props.allCampaigns
                 .slice(0, this.state.campaignsVisible)
-                .map(campaign =>
-                  <FeedCampaign
-                    key={campaign.id}
-                    data={campaign}
-                    toggled={this.props.campaignsToggled.includes(
-                      campaign.id
-                    )}
-                    navigation={navigation}
-                  />
+                .map(campaign => {
+                  if (campaign) {
+                    return (
+                      <FeedCampaign
+                        key={campaign.id}
+                        data={campaign}
+                        toggled={this.props.campaignsToggled.includes(
+                          campaign.id
+                        )}
+                        navigation={navigation}
+                      />
+                    )
+                  }
+                }
                 )}
           </View>
           {this.state.campaignsVisible < this.props.allCampaigns.length && (


### PR DESCRIPTION
Wrapped FeedCampaign component within an if-statement that checks for undefined campaigns being passed in. This issue only occurs when a new campaign was created. FeedScreens now correctly refreshes with new campaigns whenever they are created.