### PR TITLE
Fixed bug where bookmarked campaigns header was disabled

### DIFF
--- a/components/Profile/tabs/CampaignList.js
+++ b/components/Profile/tabs/CampaignList.js
@@ -25,7 +25,6 @@ const CampaignList = ({ bookmarks, fetchBookmarkedCampaigns }) => {
           <View key={campaign.id} style={styles.currentCampaigns}>
             <FeedCampaign
               displayOn="profile"
-              disableHeader
               key={campaign.id}
               data={campaign}
               toggled


### PR DESCRIPTION
# Description

Fixed bug where clicking the campaign header to go to the conservationist's profile was disabled.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code.
