### PR TITLE
Conditionally render bookmark icon if logged in user is a supporter

### DIFF
--- a/components/FeedScreen/FeedCampaign.js
+++ b/components/FeedScreen/FeedCampaign.js
@@ -155,6 +155,10 @@ const FeedCampaign = (props) => {
     navigate('Pro', { selectedProfile: data.user_id });
   };
 
+  const checkOnPress = () => {
+    console.log('YUP');
+  };
+
   const goToCampaign = async () => {
     AmpEvent('Select Profile from Campaign', {
       campaign: data.campaign_name,
@@ -308,46 +312,50 @@ const FeedCampaign = (props) => {
             </View>
           </View>
           <View style={styles.campaignControlsRight}>
-            {isSaved ? (
-              <TouchableOpacity
-                style={styles.rightSection}
-                onPress={() => {
-                  props.removeBookmark(
-                    props.currentUserProfile.id,
-                    props.data.campaign_id || props.data.comments[0].campaign_id
-                  );
-                  updateBookmarkIcon();
-                }}
-              >
-                {props.bookmarks.loading ? (
-                  <ActivityIndicator size="large" color="#ADADAD" />
-                ) : (
-                  <BookmarkSolid />
-                )}
-              </TouchableOpacity>
-            ) : (
-              <TouchableOpacity
-                style={styles.rightSection}
-                onPress={() => {
-                  props.addBookmark(
-                    props.currentUserProfile.id,
-                    props.data.campaign_id || props.data.comments[0].campaign_id
-                    // the OR condition above accounts for the fact that some campaigns
-                    // don't appear to have an ID in the (top-level) object returned from the API.
-                    // Those without a top-level ID have the campaign ID referenced in their
-                    // comments, so we can grab the ID from there. it's unclear to me if
-                    // this is a bug or the intentional behavior - worth looking into maybe?
-                  );
-                  updateBookmarkIcon();
-                }}
-              >
-                {props.bookmarks.loading ? (
-                  <ActivityIndicator size="large" color="#ADADAD" />
-                ) : (
-                  <Bookmark />
-                )}
-              </TouchableOpacity>
-            )}
+            {props.currentUserProfile.roles === 'supporter' ? (
+              isSaved ? (
+                <TouchableOpacity
+                  style={styles.rightSection}
+                  onPress={() => {
+                    props.removeBookmark(
+                      props.currentUserProfile.id,
+                      props.data.campaign_id ||
+                        props.data.comments[0].campaign_id
+                    );
+                    updateBookmarkIcon();
+                  }}
+                >
+                  {props.bookmarks.loading ? (
+                    <ActivityIndicator size="large" color="#ADADAD" />
+                  ) : (
+                    <BookmarkSolid />
+                  )}
+                </TouchableOpacity>
+              ) : (
+                <TouchableOpacity
+                  style={styles.rightSection}
+                  onPress={() => {
+                    props.addBookmark(
+                      props.currentUserProfile.id,
+                      props.data.campaign_id ||
+                        props.data.comments[0].campaign_id
+                      // the OR condition above accounts for the fact that some campaigns
+                      // don't appear to have an ID in the (top-level) object returned from the API.
+                      // Those without a top-level ID have the campaign ID referenced in their
+                      // comments, so we can grab the ID from there. it's unclear to me if
+                      // this is a bug or the intentional behavior - worth looking into maybe?
+                    );
+                    updateBookmarkIcon();
+                  }}
+                >
+                  {props.bookmarks.loading ? (
+                    <ActivityIndicator size="large" color="#ADADAD" />
+                  ) : (
+                    <Bookmark />
+                  )}
+                </TouchableOpacity>
+              )
+            ) : null}
 
             <TouchableOpacity
               style={styles.rightSection}


### PR DESCRIPTION
Remove bookmark icon if logged in user is an organization, since we don't have that functionality at the moment. 

The comment icon expanded to fill the empty space, so there's still some CSS finagling to do.

