### PR TITLE
Fix supporter profile skill selection

### DIFF
--- a/screens/EditSupporterProfileScreen.js
+++ b/screens/EditSupporterProfileScreen.js
@@ -6,7 +6,7 @@ import BackButton from '../components/BackButton';
 import DoneButton from '../components/DoneButton';
 import UploadMedia from '../components/UploadMedia';
 
-import { editProfileData, logout } from '../store/actions';
+import { editProfileData, editProfileImage, logout } from '../store/actions';
 import { AmpEvent } from '../components/withAmplitude';
 
 import styles from '../constants/screens/EditSupporterProfileScreen';
@@ -61,6 +61,9 @@ class EditSupporterProfileScreen extends React.Component {
 
   done = () => {
     let changes = this.state;
+    if (changes.profile_image) {
+      this.props.editProfileImage(this.props.currentUserProfile.id, changes.profile_image);
+    }
     this.props.editProfileData(this.props.currentUserProfile.id, changes);
     if (this.props.firstLogin) {
       this.props.navigation.navigate('Home');
@@ -251,5 +254,6 @@ const mapStateToProps = state => ({
 
 export default connect(mapStateToProps, {
   editProfileData,
+  editProfileImage,
   logout
 })(EditSupporterProfileScreen);


### PR DESCRIPTION
# Description

Fixed the skill selection in the edit profile screen.

This was quite the rabbit hole, it ended up being a compatibility issue between Axios and Express when an array is attached to a formdata object. Arrays are valid formdata values, but either Axios or Express was having trouble parsing them.

Fixed by adding a separate action for editing the profile image, where we actually need the formdata.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code.
